### PR TITLE
Truncate file in create method

### DIFF
--- a/cgfs.py
+++ b/cgfs.py
@@ -1315,7 +1315,9 @@ class CGFS(LoggingMixIn, Operations):
         parent = self.get_dir(parts[:-1])
         fname = parts[-1]
 
-        assert fname not in parent.children
+        if fname in parent.children:
+            parent.children[fname].truncate(0)
+
 
         submission = self.get_submission(path)
         query_path = submission.tld + '/' + '/'.join(parts[3:])


### PR DESCRIPTION
`man 2 creat` states:

```
       O_TRUNC
              If  the  file  already exists and is a regular file and the
	      access mode allows writing (i.e., is O_RDWR or O_WRONLY) it
	      will be truncated to length 0.  If the file is a FIFO or
	      terminal device file, the O_TRUNC flag is ignored.
	      Otherwise, the effect of O_TRUNC is unspecified.

   creat()
       A call to creat() is equivalent to calling open() with flags equal to 
       O_CREAT|O_WRONLY|O_TRUNC.
```

So calling `creat` on an existing path is not an error. I'm not entirely sure, though, if this also applies to FUSE... but in case it does, here's a PR :)
