### PR TITLE
WIP: Use Directory subclasses instead of DirTypes enum

### DIFF
--- a/cgfs.py
+++ b/cgfs.py
@@ -208,9 +208,12 @@ class AssignmentDirectory(Directory):
 
 
 class SubmissionDirectory(Directory):
-    def get_full_path(self, path):
         parts = split_path(path) if isinstance(path, str) else path
-        return self.tld + '/' + '/'.join(parts)
+    def get_full_path(self, path, is_dir=False):
+        full_path = self.tld + '/' + '/'.join(parts)
+        if (is_dir):
+            full_path += '/'
+        return full_path
 
     def load_files(self, submission):
         try:
@@ -1424,7 +1427,7 @@ class CGFS(LoggingMixIn, Operations):
             parent.insert(TempDirectory({}, name=dname, writable=True))
         else:
             submission = self.get_submission(path)
-            query_path = submission.get_full_path(parts[3:]) + '/'
+            query_path = submission.get_full_path(parts[3:], is_dir=True)
             ddata = cgapi.create_file(submission.id, query_path)
 
             parent.insert(Directory(ddata, name=dname, writable=True))

--- a/cgfs.py
+++ b/cgfs.py
@@ -145,12 +145,6 @@ class Directory(BaseFile):
         name = parts[0]
         parts = parts[1:]
 
-        if not self.children_loaded:
-            if isinstance(self, AssignmentDirectory):
-                self.load_submissions()
-            elif isinstance(self, SubmissionDirectory):
-                self.load_files()
-
         if not name in self.children:
             raise FuseOSError(ENOENT)
 
@@ -202,6 +196,11 @@ class CourseDirectory(Directory):
 
 
 class AssignmentDirectory(Directory):
+    def get_file(self, path):
+        if not self.children_loaded:
+            self.load_submissions()
+        return super(AssignmentDirectory, self).get_file(self, path)
+
     def load_submissions(self, latest_only):
         try:
             submissions = __cgapi__.get_submissions(self.id)
@@ -233,6 +232,11 @@ class AssignmentDirectory(Directory):
 
 
 class SubmissionDirectory(Directory):
+    def get_file(self, path):
+        if not self.children_loaded:
+            self.load_files()
+        return super(SubmissionDirectory, self).get_file(self, path)
+
     def get_full_path(self, path, is_dir=False):
         parts = split_path(path)
         full_path = self.tld + '/' + '/'.join(parts)

--- a/cgfs.py
+++ b/cgfs.py
@@ -69,12 +69,8 @@ def wrap_string(string, prefix, max_len):
     return ('\n').join(res), len(res) - 1
 
 
-class DirTypes(IntEnum):
-    FSROOT = 0
-    COURSE = 1
-    ASSIGNMENT = 2
-    SUBMISSION = 3
-    REGDIR = 4
+def split_path(path):
+    return [x for x in path.split('/') if x]
 
 
 class BaseFile():
@@ -109,10 +105,9 @@ class BaseFile():
 
 
 class Directory(BaseFile):
-    def __init__(self, data, name=None, type=DirTypes.REGDIR, writable=False):
+    def __init__(self, data, name=None, writable=False):
         super(Directory, self).__init__(data, name)
 
-        self.type = type
         self.writable = writable
         self.children = {}
         self.children_loaded = False
@@ -147,6 +142,105 @@ class Directory(BaseFile):
         res = list(self.children)
         res.extend(['.', '..'])
         return res
+
+
+class RootDirectory(Directory):
+    def load_courses(self):
+        for course in cgapi.get_courses():
+            course_dir = CourseDirectory(course)
+            course_dir.getattr()
+            course_dir.insert_assignments(course['assignments'])
+            self.insert(course_dir)
+        self.children_loaded = True
+
+
+class CourseDirectory(Directory):
+    def insert_assignments(self, assignments):
+        for assig in assignments:
+            assig_dir = AssignmentDirectory(assig)
+            assig_dir.getattr()
+            assig_dir.insert(AssignmentSettingsFile(cgapi, assig['id']))
+            assig_dir.insert(
+                RubricEditorFile(
+                    cgapi, assig['id'], self.rubric_append_only
+                )
+            )
+            assig_dir.insert(HelpFile(RubricEditorFile))
+            assig_dir.insert(
+                SpecialFile(
+                    '.cg-assignment-id',
+                    data=str(assig['id']).encode() + b'\n'
+                )
+            )
+            self.insert(assig_dir)
+        self.children_loaded = True
+
+
+class AssignmentDirectory(Directory):
+    def load_submissions(self, latest_only):
+        try:
+            submissions = cgapi.get_submissions(self.id)
+        except CGAPIException as e:  # pragma: no cover
+            handle_cgapi_exception(e)
+
+        seen = set()
+
+        for sub in submissions:
+            if sub['user']['id'] in seen:
+                continue
+
+            sub_dir = SubmissionDirectory(
+                sub,
+                name=sub['user']['name'] + ' - ' + sub['created_at'],
+                writable=True
+            )
+
+            if latest_only:
+                seen.add(sub['user']['id'])
+
+            sub_dir.getattr()
+            sub_dir.insert(RubricSelectFile(cgapi, sub['id'], sub['user']))
+            sub_dir.insert(GradeFile(cgapi, sub['id']))
+            sub_dir.insert(FeedbackFile(cgapi, sub['id']))
+            self.insert(sub_dir)
+
+        self.children_loaded = True
+
+
+class SubmissionDirectory(Directory):
+    def get_full_path(self, path):
+        parts = split_path(path) if isinstance(path, str) else path
+        return self.tld + '/' + '/'.join(parts)
+
+    def load_files(self, submission):
+        try:
+            files = cgapi.get_submission_files(self.id)
+        except CGAPIException as e:
+            handle_cgapi_exception(e)
+
+        def insert_tree(dir, tree):
+            for item in tree['entries']:
+                if 'entries' in item:
+                    new_dir = RegularDirectory(item, writable=self.writable)
+                    new_dir.getattr()
+                    dir.insert(new_dir)
+                    insert_tree(new_dir, item)
+                else:
+                    dir.insert(File(item))
+            dir.children_loaded = True
+
+        insert_tree(self, files)
+        self.insert(
+            SpecialFile(
+                '.cg-submission-id', data=str(submission.id).encode() + b'\n'
+            )
+        )
+        self.tld = files['name']
+        self.children_loaded = True
+
+
+class RegularDirectory(Directory):
+    pass
 
 
 class TempDirectory(Directory):
@@ -1143,11 +1237,11 @@ class CGFS(LoggingMixIn, Operations):
 
         self.rubric_append_only = rubric_append_only
 
-        self.files = Directory(
+        self.files = RootDirectory(
             {
                 'id': None,
                 'name': 'root'
-            }, type=DirTypes.FSROOT
+            }
         )
 
         with self._lock:
@@ -1166,119 +1260,31 @@ class CGFS(LoggingMixIn, Operations):
         path = os.path.abspath(path)
         return path[len(self.mountpoint):]
 
-    def load_courses(self):
-        for course in cgapi.get_courses():
-            assignments = course['assignments']
-
-            course_dir = Directory(course, type=DirTypes.COURSE)
-            course_dir.getattr()
-            self.files.insert(course_dir)
-
-            for assig in assignments:
-                assig_dir = Directory(assig, type=DirTypes.ASSIGNMENT)
-                assig_dir.getattr()
-                course_dir.insert(assig_dir)
-                assig_dir.insert(AssignmentSettingsFile(cgapi, assig['id']))
-                assig_dir.insert(
-                    RubricEditorFile(
-                        cgapi, assig['id'], self.rubric_append_only
-                    )
-                )
-                assig_dir.insert(HelpFile(RubricEditorFile))
-                assig_dir.insert(
-                    SpecialFile(
-                        '.cg-assignment-id',
-                        data=str(assig['id']).encode() + b'\n'
-                    )
-                )
-            course_dir.children_loaded = True
-        self.files.children_loaded = True
-
-    def load_submissions(self, assignment):
-        try:
-            submissions = cgapi.get_submissions(assignment.id)
-        except CGAPIException as e:  # pragma: no cover
-            handle_cgapi_exception(e)
-
-        seen = set()
-
-        for sub in submissions:
-            if sub['user']['id'] in seen:
-                continue
-
-            sub_dir = Directory(
-                sub,
-                name=sub['user']['name'] + ' - ' + sub['created_at'],
-                type=DirTypes.SUBMISSION,
-                writable=True
-            )
-
-            if self.latest_only:
-                seen.add(sub['user']['id'])
-
-            sub_dir.getattr()
-            sub_dir.insert(RubricSelectFile(cgapi, sub['id'], sub['user']))
-            sub_dir.insert(GradeFile(cgapi, sub['id']))
-            sub_dir.insert(FeedbackFile(cgapi, sub['id']))
-            assignment.insert(sub_dir)
-
-        assignment.children_loaded = True
-
-    def insert_tree(self, dir, tree):
-        for item in tree['entries']:
-            if 'entries' in item:
-                new_dir = Directory(item, writable=True)
-                new_dir.getattr()
-                dir.insert(new_dir)
-                self.insert_tree(new_dir, item)
-            else:
-                dir.insert(File(item))
-        dir.children_loaded = True
-
-    def load_submission_files(self, submission):
-        try:
-            files = cgapi.get_submission_files(submission.id)
-        except CGAPIException as e:
-            handle_cgapi_exception(e)
-        self.insert_tree(submission, files)
-        submission.insert(
-            SpecialFile(
-                '.cg-submission-id', data=str(submission.id).encode() + b'\n'
-            )
-        )
-        submission.tld = files['name']
-        submission.children_loaded = True
-
-    def split_path(self, path):
-        return [x for x in path.split('/') if x]
-
     def get_submission(self, path):
-        parts = self.split_path(path)
+        parts = split_path(path)
         submission = self.get_file(parts[:3])
-        try:
-            submission.tld
-        except AttributeError:
-            self.load_submission_files(submission)
+
+        if not isinstance(submission, SubmissionDirectory):
+            raise FuseOSError(ENOENT)
+        if not submission.children_loaded:
+            submission.load_submission_files()
 
         return submission
 
     def get_file(self, path, start=None, expect_type=None):
         file = start if start is not None else self.files
-        parts = self.split_path(path) if isinstance(path, str) else path
+        parts = split_path(path) if isinstance(path, str) else path
 
         for part in parts:
             if part == '':  # pragma: no cover
                 continue
 
             try:
-                if not any(
-                    not isinstance(f, SpecialFile)
-                    for f in file.children.values()
-                ):
-                    if file.type == DirTypes.ASSIGNMENT:
-                        self.load_submissions(file)
-                    elif file.type == DirTypes.SUBMISSION:
-                        self.load_submission_files(file)
+                if not file.children_loaded:
+                    if isinstance(file, AssignmentDirectory):
+                        file.load_submissions()
+                    elif isinstance(file, SubmissionDirectory):
+                        file.load_files()
             except AttributeError:  # pragma: no cover
                 if not isinstance(file, Directory):
                     raise FuseOSError(ENOTDIR)
@@ -1290,7 +1296,10 @@ class CGFS(LoggingMixIn, Operations):
 
         if expect_type is not None:
             if not isinstance(file, expect_type):
-                raise FuseOSError(EISDIR)
+                if issubclass(expect_type, Directory):
+                    raise FuseOSError(ENOTDIR)
+                elif issubclass(expect_type, SingleFile):
+                    raise FuseOSError(EISDIR)
 
         return file
 
@@ -1308,7 +1317,7 @@ class CGFS(LoggingMixIn, Operations):
             return self._create(path, mode)
 
     def _create(self, path, mode):
-        parts = self.split_path(path)
+        parts = split_path(path)
         if len(parts) <= 3:
             raise FuseOSError(EPERM)
 
@@ -1318,7 +1327,7 @@ class CGFS(LoggingMixIn, Operations):
         assert fname not in parent.children
 
         submission = self.get_submission(path)
-        query_path = submission.tld + '/' + '/'.join(parts[3:])
+        query_path = submission.get_full_path(parts[3:])
 
         if self.fixed:
             file = TempFile(fname, self._tmpdir)
@@ -1363,7 +1372,7 @@ class CGFS(LoggingMixIn, Operations):
 
     def _getattr(self, path, fh):
         if fh is None:
-            parts = self.split_path(path)
+            parts = split_path(path)
             file = self.get_file(parts)
         else:
             file = self._open_files[fh]
@@ -1377,7 +1386,7 @@ class CGFS(LoggingMixIn, Operations):
             except CGAPIException as e:
                 handle_cgapi_exception(e)
 
-            query_path = submission.tld + '/' + '/'.join(parts[3:])
+            query_path = submission.get_full_path(parts[3:])
 
             if isinstance(file, Directory):
                 query_path += '/'
@@ -1403,7 +1412,7 @@ class CGFS(LoggingMixIn, Operations):
             return self._mkdir(path, mode)
 
     def _mkdir(self, path, mode):
-        parts = self.split_path(path)
+        parts = split_path(path)
         parent = self.get_dir(parts[:-1])
         dname = parts[-1]
 
@@ -1415,7 +1424,7 @@ class CGFS(LoggingMixIn, Operations):
             parent.insert(TempDirectory({}, name=dname, writable=True))
         else:
             submission = self.get_submission(path)
-            query_path = submission.tld + '/' + '/'.join(parts[3:]) + '/'
+            query_path = submission.get_full_path(parts[3:]) + '/'
             ddata = cgapi.create_file(submission.id, query_path)
 
             parent.insert(Directory(ddata, name=dname, writable=True))
@@ -1425,7 +1434,7 @@ class CGFS(LoggingMixIn, Operations):
             return self._open(path, flags)
 
     def _open(self, path, flags):
-        parts = self.split_path(path)
+        parts = split_path(path)
         parent = self.get_dir(parts[:-1])
 
         file = self.get_file(parts[-1], start=parent, expect_type=SingleFile)
@@ -1453,9 +1462,9 @@ class CGFS(LoggingMixIn, Operations):
             dir = self.get_dir(path)
 
             if not dir.children_loaded:
-                if dir.type == DirTypes.ASSIGNMENT:
+                if isinstance(dir, AssignmentDirectory):
                     self.load_submissions(dir)
-                elif dir.type == DirTypes.SUBMISSION:
+                elif isinstance(dir, SubmissionDirectory):
                     self.load_submission_files(dir)
 
             return dir.read()
@@ -1478,14 +1487,14 @@ class CGFS(LoggingMixIn, Operations):
             self._rename(old, new)
 
     def _rename(self, old, new):
-        old_parts = self.split_path(old)
+        old_parts = split_path(old)
         old_parent = self.get_dir(old_parts[:-1])
         file = self.get_file(old_parts[-1], start=old_parent)
 
         if isinstance(file, SpecialFile):
             raise FuseOSError(EPERM)
 
-        new_parts = self.split_path(new)
+        new_parts = split_path(new)
         new_parent = self.get_dir(new_parts[:-1])
 
         if new_parts[-1] in new_parent.children:
@@ -1498,7 +1507,7 @@ class CGFS(LoggingMixIn, Operations):
         if submission.id != self.get_submission(new).id:
             raise FuseOSError(EPERM)
 
-        new_query_path = submission.tld + '/' + '/'.join(new_parts[3:]) + '/'
+        new_query_path = submission.full_path(new_parts[3:]) + '/'
 
         if not isinstance(file, (TempDirectory, TempFile)):
             if self.fixed:
@@ -1520,11 +1529,11 @@ class CGFS(LoggingMixIn, Operations):
             self._rmdir(path)
 
     def _rmdir(self, path):
-        parts = self.split_path(path)
+        parts = split_path(path)
         parent = self.get_dir(parts[:-1])
         dir = self.get_file(parts[-1], start=parent)
 
-        if dir.type != DirTypes.REGDIR:
+        if not isinstance(dir, RegularDirectory):
             raise FuseOSError(EPERM)
         if dir.children:
             raise FuseOSError(ENOTEMPTY)
@@ -1573,7 +1582,7 @@ class CGFS(LoggingMixIn, Operations):
 
     def unlink(self, path):
         with self._lock:
-            parts = self.split_path(path)
+            parts = split_path(path)
             parent = self.get_dir(parts[:-1])
             fname = parts[-1]
             file = self.get_file(fname, start=parent, expect_type=SingleFile)


### PR DESCRIPTION
## Description
Make subclasses of the `Directory` class to be used instead of the `DirTypes` enum.
The new classes are: `RootDirectory`, `CourseDirectory`, `AssignmentDirectory`, `SubmissionDirectory` and `RegularDirectory`, named after the corresponding values of the enum.
Also moves some functionality specific to those directories to the new classes, e.g. loading submissions is now in the `AssignmentDirectory` class.

Still WIP as I haven't been able to test it yet, but wanted to get it out there to get some initial feedback on it.
