### PR TITLE
Fix a memory leak in the rubric parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@
 
 ## Installation
 You can install this package using `pip`. At the moment this package is not yet
-in the pip repositories, however you can install it directly from git: `pip3
-install --user git+https://github.com/CodeGra-de/CodeGra.fs.git`. This installs
-to scripts, `cgfs` used to mount the file-system and `cgapi-consumer` used by
-editor plugins.
+in the pip repositories, however you can install it directly from git: `sudo
+pip3 install git+https://github.com/CodeGra-de/CodeGra.fs.git`. This installs
+two scripts, `cgfs` used to mount the file-system and `cgapi-consumer` used by
+editor plugins. You can also install `cgfs` by giving `pip` the `--user` flag,
+however make sure `$HOME/.local/bin` is in your `$PATH` in this case.
 
 Please note that `pip3` is used, this because CodeGra.fs only with works with
 python **3.5** or higher. It depends on:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import sys
 from distutils.core import setup
 
-version = '0.2.0'
+version = '0.3.0'
 
 if sys.version_info < (3, 5):
     print('Sorry only python 3.5 and up is supported', file=sys.stderr)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,8 +8,9 @@ import tempfile
 import contextlib
 import subprocess
 
-import pytest
 import requests
+
+import pytest
 
 
 @pytest.fixture(autouse=True)
@@ -110,7 +111,7 @@ def assig_done(mount, shell_id, mount_dir):
 def sub_done2(assig_done):
     print(os.listdir(assig_done))
     for path in reversed(sorted(os.listdir(assig_done))):
-        if 'Stupid2' in path:
+        if 'Student2' in path:
             return os.path.join(assig_done, path)
 
 
@@ -118,14 +119,14 @@ def sub_done2(assig_done):
 def sub_done(assig_done):
     print(os.listdir(assig_done))
     for path in reversed(sorted(os.listdir(assig_done))):
-        if 'Stupid1' in path:
+        if 'Student1' in path:
             return os.path.join(assig_done, path)
 
 
 @pytest.fixture(autouse=True)
 def sub_open(assig_open):
     for path in reversed(sorted(os.listdir(assig_open))):
-        if 'Stupid1' in path:
+        if 'Student1' in path:
             return os.path.join(assig_open, path)
 
 
@@ -143,8 +144,8 @@ def teacher_jwt():
 def student_jwt():
     req = requests.post(
         'http://localhost:5000/api/v1/login',
-        json={'username': 'stupid1',
-              'password': 'Stupid1'}
+        json={'username': 'student1',
+              'password': 'Student1'}
     )
     return req.json()['access_token']
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -6,9 +6,9 @@ import tarfile
 import subprocess
 import urllib.request
 
-import pytest
 import requests
 
+import pytest
 from helpers import (
     ls, rm, join, chmod, chown, isdir, mkdir, rm_rf, rmdir, isfile, rename,
     symlink
@@ -23,12 +23,12 @@ def run_shell(prog, **kwargs):
 
 @pytest.fixture(autouse=True)
 def username():
-    yield 'thomas'
+    yield 'robin'
 
 
 @pytest.fixture(autouse=True)
 def password():
-    yield 'Thomas Schaper'
+    yield 'Robin'
 
 
 @pytest.mark.parametrize(
@@ -80,6 +80,7 @@ def password():
         (b'# Header\nDescription\n----\n(1.0) Item - Desc', False),
         (b'# Header\nDescription\n----\n- (1.0) Item - Desc\n# C', False),
         (b'# Header\nDescription\n----\n- [noid] (1.0) Item - Desc\n', False),
+        (b'# Header\nDescription\n----\n- (1.0) Item\n', False),
     ]
 )
 def test_get_set_rubric(

--- a/test/test_fixed.py
+++ b/test/test_fixed.py
@@ -5,7 +5,6 @@ import subprocess
 import urllib.request
 
 import pytest
-
 from helpers import (
     ls, rm, join, chmod, chown, isdir, mkdir, rm_rf, rmdir, isfile, rename,
     symlink
@@ -14,12 +13,12 @@ from helpers import (
 
 @pytest.fixture(autouse=True)
 def username():
-    yield 'stupid1'
+    yield 'student1'
 
 
 @pytest.fixture(autouse=True)
 def password():
-    yield 'Stupid1'
+    yield 'Student1'
 
 
 @pytest.mark.parametrize('fixed', [False], indirect=True)

--- a/test/test_general.py
+++ b/test/test_general.py
@@ -5,7 +5,6 @@ import subprocess
 import urllib.request
 
 import pytest
-
 from helpers import (
     ls, rm, join, chmod, chown, isdir, mkdir, rm_rf, rmdir, isfile, rename,
     symlink
@@ -192,7 +191,7 @@ def test_compiling_program(sub_done, mount, fixed):
 def test_latest_only(assig_done, latest_only):
     amount = 0
     for item in ls(assig_done):
-        amount += 1 if 'Stupid1' in item else 0
+        amount += 1 if 'Student1' in item else 0
     if latest_only:
         assert amount == 1
     else:

--- a/test/test_student.py
+++ b/test/test_student.py
@@ -1,16 +1,15 @@
 import pytest
-
 from helpers import ls, rm, join, isdir, mkdir, rm_rf, rmdir, isfile
 
 
 @pytest.fixture(autouse=True)
 def username():
-    yield 'stupid1'
+    yield 'student1'
 
 
 @pytest.fixture(autouse=True)
 def password():
-    yield 'Stupid1'
+    yield 'Student1'
 
 
 def test_list_courses(mount_dir):
@@ -36,13 +35,13 @@ def test_list_submissions(mount_dir, mount):
 
     for assig in ls(course_dir):
         for sub in ls(course_dir, assig):
-            assert 'Stupid1' in sub or sub[0] == '.'
+            assert 'Student1' in sub or sub[0] == '.'
 
     mount(assigned_to_me=True)
 
     for assig in ls(course_dir):
         for sub in ls(course_dir, assig):
-            assert 'Stupid1' in sub or sub[0] == '.'
+            assert 'Student1' in sub or sub[0] == '.'
 
 
 def test_create_files(mount_dir, sub_open, sub_done):

--- a/test/test_teacher.py
+++ b/test/test_teacher.py
@@ -1,17 +1,17 @@
-import pytest
 import requests
 
+import pytest
 from helpers import ls, rm, join, isdir, mkdir, rm_rf, rmdir, isfile
 
 
 @pytest.fixture(autouse=True)
 def username():
-    yield 'thomas'
+    yield 'robin'
 
 
 @pytest.fixture(autouse=True)
 def password():
-    yield 'Thomas Schaper'
+    yield 'Robin'
 
 
 @pytest.fixture
@@ -58,7 +58,7 @@ def test_list_submissions(mount_dir):
         for assig in ls(mount_dir, course):
             for sub in ls(mount_dir, course, assig):
                 assert any(
-                    'Stupid{i}'.format(i=i) in sub for i in range(1, 5)
+                    'Student{i}'.format(i=i) in sub for i in range(1, 5)
                 ) or 'Œlµo' in sub or sub[0] == '.'
 
     for assig in ls(mount_dir, 'Project Software Engineering'):
@@ -71,7 +71,7 @@ def test_list_assigned_submissions(mount, mount_dir, teacher_jwt, teacher_id):
 
     for assig in ls(mount_dir, course):
         for sub in ls(mount_dir, course, assig):
-            if 'Stupid1' in sub:
+            if 'Student1' in sub:
                 with open(join(mount_dir, course, assig, sub, '.cg-submission-id')) as f:
                     sub_id = f.read().strip()
                 r = requests.patch(
@@ -87,7 +87,7 @@ def test_list_assigned_submissions(mount, mount_dir, teacher_jwt, teacher_id):
 
     for assig in ls(mount_dir, course):
         for sub in ls(mount_dir, course, assig):
-            assert 'Stupid1' in sub or sub[0] == '.'
+            assert 'Student1' in sub or sub[0] == '.'
 
 
 def test_create_files(mount_dir, sub_open, sub_done):

--- a/test/test_teacher.py
+++ b/test/test_teacher.py
@@ -4,14 +4,14 @@ import pytest
 from helpers import ls, rm, join, isdir, mkdir, rm_rf, rmdir, isfile
 
 
-@pytest.fixture(autouse=True)
-def username():
-    yield 'robin'
+@pytest.fixture(autouse=True, params=['robin'])
+def username(request):
+    yield request.param
 
 
-@pytest.fixture(autouse=True)
-def password():
-    yield 'Robin'
+@pytest.fixture(autouse=True, params=['Robin'])
+def password(request):
+    yield request.param
 
 
 @pytest.fixture
@@ -53,6 +53,8 @@ def test_list_assignments(mount_dir):
         assert isdir(mount_dir, 'Programmeertalen', assig)
 
 
+@pytest.mark.parametrize('username', ['thomas'], indirect=True)
+@pytest.mark.parametrize('password', ['Thomas Schaper'], indirect=True)
 def test_list_submissions(mount_dir):
     for course in ['Besturingssystemen', 'Programmeertalen']:
         for assig in ls(mount_dir, course):


### PR DESCRIPTION
## Description
This leak was cased by rubrics that looked like this:
```
 # Item
 ------------------
 - (5.0) Header without description
 - (10.0) Header without description2
 ```
This rubric is invalid, however this resulted in `cgfs` using all the memory on
a system. This is fixed by disallowing newlines in rubric item headers.

This closes #15.