### PR TITLE
Declared encoding when reading the README for proper Python3 compatib…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email='info@codegra.de',
     version=version,
     description='File-system for CodeGra.de instances',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', 'r', encoding='utf-8').read(),
     install_requires=['requests>=2.18.4', 'fusepy>=2.0.4'],
     packages=['codegra_fs'],
     entry_points={


### PR DESCRIPTION

## Description
Since the installation failed on Ubuntu 18.04 with Python3.6.5 on the encoding of the README,  now the encoding of the file is explicitly declared in the open call.

## Checklist:
- [ ] Tests
Not tested

