### PR TITLE
Fix fsync bug that prevented editing teacher files

### DIFF
--- a/codegra_fs/cgfs.py
+++ b/codegra_fs/cgfs.py
@@ -978,7 +978,7 @@ class File(BaseFile, SingleFile):
         return len(data)
 
     def fsync(self):
-        self.flush()
+        return self.flush()
 
 
 class APIHandler:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version=version,
     description='File-system for CodeGra.de instances',
     long_description=open('README.md').read(),
-    install_requires=['requests>=2.18.4', 'fusepy>=2.0.4'],
+    install_requires=['requests>=2.18.4', 'fusepy>=2.0.4, <3.0.0'],
     packages=['codegra_fs'],
     entry_points={
         'console_scripts':


### PR DESCRIPTION
When using `fysync` to sync data to disk the function `fsync` was called on the
file object, which calls `File.flush`. This function returns a serialized code
object when it got such an object from the server. However, the `File.fsync`
function didn't return `File.flush`, so the updated file `id` was never
saved. This PR fixes this issue.