### PR TITLE
Make CodeGra.fs ready for publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@
 
 ## Installation
 You can install this package using `pip`. At the moment this package is not yet
-in the pip repositories, however you can install it directly from git: `sudo
-pip3 install git+https://github.com/CodeGra-de/CodeGra.fs.git`. This installs
-two scripts, `cgfs` used to mount the file-system and `cgapi-consumer` used by
-editor plugins. You can also install `cgfs` by giving `pip` the `--user` flag,
-however make sure `$HOME/.local/bin` is in your `$PATH` in this case.
+in the pip repositories, however you can install it directly from git: `sudo pip
+install CodeGra.fs`. This installs two scripts, `cgfs` used to mount the
+file-system and `cgapi-consumer` used by editor plugins. You can also install
+`cgfs` by giving `pip` the `--user` flag, however make sure `$HOME/.local/bin`
+is in your `$PATH` in this case.
 
 Please note that `pip3` is used, this because CodeGra.fs only with works with
 python **3.5** or higher. It depends on:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import sys
-from distutils.core import setup
 
-version = '0.3.1'
+from setuptools import setup
+
+version = '0.3.2'
 
 if sys.version_info < (3, 5):
     print('Sorry only python 3.5 and up is supported', file=sys.stderr)
@@ -11,12 +12,13 @@ if sys.version_info < (3, 5):
 
 setup(
     name='CodeGra.fs',
-    author='The CodeGra.de team',
+    author='The CodeGrade team',
     author_email='info@codegra.de',
     version=version,
-    description='File-system for CodeGra.de instances',
-    install_requires=['requests>=2.18.4', 'fusepy>=2.0.4, <3.0.0'],
+    description='File-system for CodeGrade instances',
+    install_requires=['requests>=2.18.4', 'fusepy>=2.0.4,<3.0.0'],
     long_description=open('README.md', 'r', encoding='utf-8').read(),
+    long_description_content_type="text/markdown",
     packages=['codegra_fs'],
     entry_points={
         'console_scripts':
@@ -24,5 +26,11 @@ setup(
                 'cgfs = codegra_fs.cgfs:main',
                 'cgapi-consumer = codegra_fs.api_consumer:main'
             ]
-    }
+    },
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'Operating System :: POSIX',
+        'Operating System :: MacOS',
+    ],
 )


### PR DESCRIPTION
We now use `setuptools` instead of `distutils` and I updated the readme.